### PR TITLE
refactor: optimize diff rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,7 +589,23 @@
         
         renderStats();
       }
-      
+
+      // Build a document fragment from diff parts to minimize DOM updates
+      function buildDiffFragment(parts) {
+        const fragment = document.createDocumentFragment();
+        parts.forEach(part => {
+          const span = document.createElement('span');
+          span.textContent = part.text;
+          if (part.type === 'deletion') {
+            span.classList.add('deleted');
+          } else if (part.type === 'insertion') {
+            span.classList.add('inserted');
+          }
+          fragment.appendChild(span);
+        });
+        return fragment;
+      }
+
       // Render side-by-side view
       function renderSideBySide() {
         // Group diff parts for original and AI texts
@@ -608,42 +624,17 @@
         
         // Render original text
         originalDiff.innerHTML = '';
-        originalParts.forEach(part => {
-          const span = document.createElement('span');
-          span.textContent = part.text;
-          if (part.type === 'deletion') {
-            span.classList.add('deleted');
-          }
-          originalDiff.appendChild(span);
-        });
-        
+        originalDiff.appendChild(buildDiffFragment(originalParts));
+
         // Render AI text
         aiDiff.innerHTML = '';
-        aiParts.forEach(part => {
-          const span = document.createElement('span');
-          span.textContent = part.text;
-          if (part.type === 'insertion') {
-            span.classList.add('inserted');
-          }
-          aiDiff.appendChild(span);
-        });
+        aiDiff.appendChild(buildDiffFragment(aiParts));
       }
-      
+
       // Render unified view
       function renderUnified() {
         diffUnified.innerHTML = '';
-        state.diffResult.forEach(part => {
-          const span = document.createElement('span');
-          span.textContent = part.text;
-          
-          if (part.type === 'deletion') {
-            span.classList.add('deleted');
-          } else if (part.type === 'insertion') {
-            span.classList.add('inserted');
-          }
-          
-          diffUnified.appendChild(span);
-        });
+        diffUnified.appendChild(buildDiffFragment(state.diffResult));
       }
       
       // Render statistics


### PR DESCRIPTION
## Summary
- reduce duplicate DOM creation by batching diff spans into document fragments
- reuse shared fragment builder for side-by-side and unified views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689633632024832daf5d77bd70c5d033